### PR TITLE
Silence alarm sound when puzzle screen becomes visible

### DIFF
--- a/app/src/main/java/com/example/chessalarm/PuzzleActivity.java
+++ b/app/src/main/java/com/example/chessalarm/PuzzleActivity.java
@@ -56,6 +56,14 @@ public class PuzzleActivity extends AppCompatActivity implements AlarmStateListe
     }
 
     @Override
+    protected void onResume() {
+        super.onResume();
+        // Once the puzzle screen is visible, the alarm has done its job of waking the user.
+        // Silence the sound so solving isn't drowned out — state stays RINGING until dismissed.
+        AlarmController.getInstance(this).silence();
+    }
+
+    @Override
     protected void onDestroy() {
         AlarmController.getInstance(this).removeListener(this);
         super.onDestroy();

--- a/app/src/main/java/com/example/chessalarm/alarm/AlarmController.java
+++ b/app/src/main/java/com/example/chessalarm/alarm/AlarmController.java
@@ -62,4 +62,13 @@ public class AlarmController {
             l.onAlarmDismissed();
         }
     }
+
+    /**
+     * Stops the alarm sound without dismissing the alarm. State remains {@link State#RINGING}
+     * so the user must still solve the puzzle to fully dismiss. No-op when idle.
+     */
+    public void silence() {
+        if (state == State.IDLE) return;
+        new StopAlarmCommand(soundPlayer).execute();
+    }
 }

--- a/app/src/test/java/com/example/chessalarm/alarm/AlarmControllerTest.java
+++ b/app/src/test/java/com/example/chessalarm/alarm/AlarmControllerTest.java
@@ -100,4 +100,25 @@ public class AlarmControllerTest {
         assertEquals(0, sound.stops);
         assertSame(AlarmController.State.IDLE, controller.getState());
     }
+
+    @Test
+    public void silenceStopsSoundButLeavesStateRinging() {
+        RecordingListener listener = new RecordingListener();
+        controller.addListener(listener);
+        controller.trigger();
+
+        controller.silence();
+
+        assertEquals(1, sound.stops);
+        assertSame(AlarmController.State.RINGING, controller.getState());
+        assertEquals(0, listener.dismissed);
+    }
+
+    @Test
+    public void silenceWhileIdleIsNoOp() {
+        controller.silence();
+
+        assertEquals(0, sound.stops);
+        assertSame(AlarmController.State.IDLE, controller.getState());
+    }
 }


### PR DESCRIPTION
Adds AlarmController.silence() — stops the ringtone but leaves state as RINGING, so the user must still solve the puzzle to fully dismiss. PuzzleActivity calls it from onResume(), so the brief sound between AlarmReceiver firing and the activity appearing is enough to wake the user without drowning out the solving experience.

Also adds two AlarmControllerTest cases covering silence behavior.